### PR TITLE
Initial configuration for GitHub Actions

### DIFF
--- a/.github/workflows/on-change.yaml
+++ b/.github/workflows/on-change.yaml
@@ -1,0 +1,27 @@
+---
+name: "Syncron"
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Clone repository"
+        uses: actions/checkout@v3
+      - name: "Setup Go"
+        uses: actions/setup-go@v3
+        with:
+          go-version: ">=1.17.0"
+      - name: "Run linter - StaticCheck"
+        uses: dominikh/staticcheck-action@v1.2.0
+        with:
+          version: "2022.1"
+          install-go: false
+      - name: "Build binary - Server"
+        run: go build -o .go/builds/server cmd/server.go
+      - name: "Run tests - All"
+        run: go test ./...


### PR DESCRIPTION
The pipeline will trigger on a change to 'main' and on PRs.

It replicates the default workflow setup by Go's VSCode plugin, which is:
    - Install Go -> >= 1.17
    - Run StaticCheck, a linter.
    - Build binaries, server.go for now.
    - Run all tests.

The pipeline will need a few adjustments later on:
    - Build adhoc binary too.
    - Differentiate between unit and other tests.

Decisions taken:
    - Build files go under the '.go' folder.
    - We will target latest version of StaticCheck as of now -> 2022.1.
    - Ignored other linters like Go Vet or Go Lint unless explicitly desired.