### PR TITLE
Defining CLI for adhoc mode

### DIFF
--- a/cmd/adhoc/cmd/download.go
+++ b/cmd/adhoc/cmd/download.go
@@ -1,0 +1,16 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var download = &cobra.Command{
+	Use:  "download",
+	RunE: onRun,
+}
+
+func init() {
+	root.AddCommand(download)
+}
+
+func onRun(cmd *cobra.Command, args []string) error {
+	return nil
+}

--- a/cmd/adhoc/cmd/download.go
+++ b/cmd/adhoc/cmd/download.go
@@ -3,11 +3,17 @@ package cmd
 import "github.com/spf13/cobra"
 
 var download = &cobra.Command{
-	Use:  "download",
-	RunE: onRun,
+	Use:       "download",
+	Args:      cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+	ValidArgs: []string{"insights", "sosreports", "all"},
+	RunE:      onRun,
 }
 
 func init() {
+	download.Flags().Int("days", 3, "Download data from the last X days")
+	download.Flags().Int("months", 0, "Download data from the last X months")
+	download.Flags().Int("years", 0, "Download data from the last X years")
+
 	root.AddCommand(download)
 }
 

--- a/cmd/adhoc/cmd/root.go
+++ b/cmd/adhoc/cmd/root.go
@@ -1,0 +1,14 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var root = &cobra.Command{
+	Use: "syncron",
+}
+
+func Execute() error {
+	return root.Execute()
+}
+
+func init() {
+}

--- a/cmd/adhoc/cmd/root.go
+++ b/cmd/adhoc/cmd/root.go
@@ -11,4 +11,5 @@ func Execute() error {
 }
 
 func init() {
+	root.PersistentFlags().BoolP("debug", "d", false, "Turn on debug mode")
 }

--- a/cmd/adhoc/main.go
+++ b/cmd/adhoc/main.go
@@ -1,4 +1,15 @@
 package main
 
+import (
+	"log"
+
+	"github.com/rhcre/syncron/cmd/adhoc/cmd"
+)
+
 func main() {
+	err := cmd.Execute()
+
+	if err != nil {
+		log.Fatal(err)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module github.com/rhcre/syncron
 
 go 1.17
+
+require github.com/spf13/cobra v1.5.0
+
+require (
+	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
+github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.5.0 h1:X+jTBEBqF0bHN+9cSMgmfuvv2VHJ9ezmFNf9Y/XstYU=
+github.com/spf13/cobra v1.5.0/go.mod h1:dWXEIy2H428czQCjInthrTRUg7yKbok+2Qi/yBIJoUM=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=


### PR DESCRIPTION
I have chosen the Cobra framework to deal with the CLI side of Syncron. This one seems to be pretty standard for GoLang and is comfortable to use.

Through it, I have described the CLI for Adhoc mode following the same arguments as we had on UpGet. Here is an example of how it looks like:
`syncron download all --months 1`

If you want to try for yourself, run:
`go run cmd/adhoc/main.go`