### PR TITLE
Publishing binaries as artifacts on GitHub Actions

### DIFF
--- a/.github/workflows/on-change.yaml
+++ b/.github/workflows/on-change.yaml
@@ -27,3 +27,8 @@ jobs:
         run: go build -o .go/builds/server cmd/server/main.go
       - name: "Run tests - All"
         run: go test ./...
+      - name: "Publish artifacts - Binaries"
+        uses: actions/upload-artifact@v3
+        with:
+          name: "Binaries"
+          path: .go/builds


### PR DESCRIPTION
GitHub Actions job will now publish as artifacts the binaries built during the run. These binaries include both the adhoc and server entrypoints, named both as such. 

This will ease reviews as it will not be necessary to have the development environment in order to try out the app.

See exported artifacts by this PR's build here: https://github.com/RedHatCRE/syncron/actions/runs/3089275971