### PR TITLE
Restructuring code to allow for unit testing

### DIFF
--- a/cmd/adhoc/cmd/download.go
+++ b/cmd/adhoc/cmd/download.go
@@ -9,25 +9,25 @@ import (
 var download = &cobra.Command{
 	Use:       "download",
 	Args:      cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
-	ValidArgs: []string{cli.INSIGHTS_A, cli.SOSREPORTS_A, cli.ALL_A},
+	ValidArgs: []string{cli.Insights, cli.SOSReports, cli.All},
 	RunE:      onRun,
 }
 
 func init() {
 	download.Flags().Int(
-		cli.DAYS_F,
+		cli.Days,
 		3,
 		"Download data from the last X days",
 	)
 
 	download.Flags().Int(
-		cli.MONTHS_F,
+		cli.Months,
 		0,
 		"Download data from the last X months",
 	)
 
 	download.Flags().Int(
-		cli.YEARS_F,
+		cli.Years,
 		0,
 		"Download data from the last X years",
 	)

--- a/cmd/adhoc/cmd/root.go
+++ b/cmd/adhoc/cmd/root.go
@@ -17,8 +17,8 @@ func Execute() error {
 
 func init() {
 	root.PersistentFlags().BoolP(
-		cli.DEBUG_F,
-		cli.DEBUG_P,
+		cli.Debug,
+		cli.D,
 		false,
 		"Turn on debug mode",
 	)

--- a/cmd/adhoc/cmd/root.go
+++ b/cmd/adhoc/cmd/root.go
@@ -29,12 +29,9 @@ func onPersistentPreRun(cmd *cobra.Command, args []string) error {
 	setup := []func() error{
 		// Set up logging
 		func() error {
-			return log.Configure(
-				cli.Input{
-					Cmd:  cmd,
-					Args: args,
-				},
-			)
+			parser := cli.NewParserForCobra(cmd, args)
+
+			return log.Configure(parser)
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/objx v0.4.0 // indirect
 	golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -15,12 +15,12 @@ github.com/spf13/cobra v1.5.0/go.mod h1:dWXEIy2H428czQCjInthrTRUg7yKbok+2Qi/yBIJ
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0 h1:M2gUjqZET1qApGOWNSnZ49BAIMX4F/1plDv3+l31EJ4=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 h1:h+EGohizhe9XlX18rfpa8k8RAc5XyaeamM+0VHRd4lc=
 golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/cli/args.go
+++ b/pkg/cli/args.go
@@ -2,21 +2,21 @@ package cli
 
 // Keywords used as arguments on the CLI.
 const (
-	INSIGHTS_A   string = "insights"
-	SOSREPORTS_A string = "sosreports"
-	ALL_A        string = "all"
+	Insights   string = "insights"
+	SOSReports string = "sosreports"
+	All        string = "all"
 )
 
 // Keywords used as flags on the CLI.
 const (
-	DEBUG_F string = "debug"
+	Debug string = "debug"
 
-	DAYS_F   string = "days"
-	MONTHS_F string = "months"
-	YEARS_F  string = "years"
+	Days   string = "days"
+	Months string = "months"
+	Years  string = "years"
 )
 
 // Keywords used as shortcuts on the CLI.
 const (
-	DEBUG_P string = "d"
+	D string = "d"
 )

--- a/pkg/cli/parsers.go
+++ b/pkg/cli/parsers.go
@@ -38,12 +38,12 @@ func NewParserForCobra(cmd *cobra.Command, args []string) *CobraParser {
 // GetDebug implements cli.CLIParser.GetDebug by extracting the value of the
 // 'debug' flag from Cobra's input data.
 func (parser *CobraParser) GetDebug() bool {
-	val, err := parser.cmd.Flags().GetBool(DEBUG_F)
+	val, err := parser.cmd.Flags().GetBool(Debug)
 
 	if err != nil {
 		logrus.Errorf(
 			"Unable to read value for argument: '%s'. Reason: '%s'.",
-			DEBUG_F, err,
+			Debug, err,
 		)
 
 		logrus.Warn(

--- a/pkg/cli/parsers.go
+++ b/pkg/cli/parsers.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+type CLIParser interface {
+	GetDebug() bool
+}
+
+type CobraParser struct {
+	cmd  *cobra.Command
+	args []string
+}
+
+func NewParserForCobra(cmd *cobra.Command, args []string) *CobraParser {
+	result := new(CobraParser)
+
+	result.cmd = cmd
+	result.args = args
+
+	return result
+}
+
+func (parser *CobraParser) GetDebug() bool {
+	val, err := parser.cmd.Flags().GetBool(DEBUG_F)
+
+	if err != nil {
+		logrus.Errorf(
+			"Unable to read value for argument: '%s'. Reason: '%s'.",
+			DEBUG_F, err,
+		)
+
+		logrus.Warn(
+			"Continuing without debug messages...",
+		)
+
+		return false
+	}
+
+	return val
+}

--- a/pkg/cli/parsers.go
+++ b/pkg/cli/parsers.go
@@ -25,7 +25,7 @@ type CobraParser struct {
 }
 
 // NewParserForCobra returns a new cli.CobraParser that will get to work with
-// the Cobra structures given to this.
+// the Cobra structures given to it.
 func NewParserForCobra(cmd *cobra.Command, args []string) *CobraParser {
 	result := new(CobraParser)
 

--- a/pkg/cli/parsers.go
+++ b/pkg/cli/parsers.go
@@ -5,15 +5,27 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// CLIParser makes sense out of the data retrieved from a CLI framework.
+//
+// An implementation will ease access to the options the user has defined
+// through the command line, such as the logging mode or the location of a
+// configuration file.
 type CLIParser interface {
+	// GetDebug indicates whether the debug mode for Syncron has been
+	// requested (true) or not (false).
 	GetDebug() bool
 }
 
+// CobraParser takes care of extracting all interesting data from the
+// structures provided by the Cobra CLI framework by implementing the
+// cli.CLIParser interface.
 type CobraParser struct {
 	cmd  *cobra.Command
 	args []string
 }
 
+// NewParserForCobra returns a new cli.CobraParser that will get to work with
+// the Cobra structures given to this.
 func NewParserForCobra(cmd *cobra.Command, args []string) *CobraParser {
 	result := new(CobraParser)
 
@@ -23,6 +35,8 @@ func NewParserForCobra(cmd *cobra.Command, args []string) *CobraParser {
 	return result
 }
 
+// GetDebug implements cli.CLIParser.GetDebug by extracting the value of the
+// 'debug' flag from Cobra's input data.
 func (parser *CobraParser) GetDebug() bool {
 	val, err := parser.cmd.Flags().GetBool(DEBUG_F)
 

--- a/pkg/cli/types.go
+++ b/pkg/cli/types.go
@@ -1,9 +1,0 @@
-package cli
-
-import "github.com/spf13/cobra"
-
-// Input represents all data that the user provided through the CLI.
-type Input struct {
-	Cmd  *cobra.Command
-	Args []string
-}

--- a/pkg/log/config.go
+++ b/pkg/log/config.go
@@ -26,9 +26,11 @@ func Configure(parser cli.CLIParser) error {
 		},
 	}
 
+	// Run all steps defined above
 	for _, step := range setup {
 		err := step()
 
+		// Halt if the setup failed
 		if err != nil {
 			return err
 		}

--- a/pkg/log/config.go
+++ b/pkg/log/config.go
@@ -11,20 +11,14 @@ import (
 // At this moment, Configure supports the following flags from the CLI:
 //   - '-d'
 //   - '--debug'
-func Configure(in cli.Input) error {
+func Configure(parser cli.CLIParser) error {
 	// Define all actions needed to get Logrus ready to go
 	setup := []func() error{
 		// Set log level
 		func() error {
-			debug, err := in.Cmd.Flags().GetBool(cli.DEBUG_F)
-
-			if err != nil {
-				return err
-			}
-
 			logrus.SetLevel(logrus.InfoLevel)
 
-			if debug {
+			if parser.GetDebug() {
 				logrus.SetLevel(logrus.TraceLevel)
 			}
 

--- a/pkg/log/config_test.go
+++ b/pkg/log/config_test.go
@@ -3,6 +3,9 @@ package log_test
 import (
 	"testing"
 
+	"github.com/rhcre/syncron/pkg/log"
+	"github.com/rhcre/syncron/test/mocks"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -11,8 +14,22 @@ type ConfigureTestSuite struct {
 	suite.Suite
 }
 
+func (suite *ConfigureTestSuite) TestLevelOnDebug() {
+	parser := new(mocks.CLIParserMock)
+	parser.On("GetDebug").Return(true)
+
+	log.Configure(parser)
+
+	assert.Equal(suite.T(), logrus.TraceLevel, logrus.GetLevel())
+}
+
 func (suite *ConfigureTestSuite) TestLevelOnNoDebug() {
-	assert.True(suite.T(), true)
+	parser := new(mocks.CLIParserMock)
+	parser.On("GetDebug").Return(false)
+
+	log.Configure(parser)
+
+	assert.Equal(suite.T(), logrus.InfoLevel, logrus.GetLevel())
 }
 
 func TestConfigureTestSuite(t *testing.T) {

--- a/pkg/log/config_test.go
+++ b/pkg/log/config_test.go
@@ -10,10 +10,13 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+// ConfigureTestSuite groups all tests that target Configure.
 type ConfigureTestSuite struct {
 	suite.Suite
 }
 
+// TestLevelOnDebug calls log.Configure, checking for logrus.TraceLevel to be
+// Logrus's level when '-d' is present on the CLI.
 func (suite *ConfigureTestSuite) TestLevelOnDebug() {
 	parser := new(mocks.CLIParserMock)
 	parser.On("GetDebug").Return(true)
@@ -23,6 +26,8 @@ func (suite *ConfigureTestSuite) TestLevelOnDebug() {
 	assert.Equal(suite.T(), logrus.TraceLevel, logrus.GetLevel())
 }
 
+// TestLevelOnNoDebug calls log.Configure, checking for logrus.InfoLevel to be
+// Logrus's level when '-d' is not present on the CLI.
 func (suite *ConfigureTestSuite) TestLevelOnNoDebug() {
 	parser := new(mocks.CLIParserMock)
 	parser.On("GetDebug").Return(false)
@@ -32,6 +37,8 @@ func (suite *ConfigureTestSuite) TestLevelOnNoDebug() {
 	assert.Equal(suite.T(), logrus.InfoLevel, logrus.GetLevel())
 }
 
+// TestConfigureTestSuite takes care of running all tests
+// on ConfigureTestSuite.
 func TestConfigureTestSuite(t *testing.T) {
 	suite.Run(t, new(ConfigureTestSuite))
 }

--- a/test/mocks/cli.go
+++ b/test/mocks/cli.go
@@ -1,0 +1,13 @@
+package mocks
+
+import "github.com/stretchr/testify/mock"
+
+type CLIParserMock struct {
+	mock.Mock
+}
+
+func (mock *CLIParserMock) GetDebug() bool {
+	args := mock.Called()
+
+	return args.Bool(0)
+}


### PR DESCRIPTION
On this PR:
  - Reworked cli.Input into the cli.CLIParser interface so that it is mockable.
  - Retrieving 'd' and 'debug' values through CobraParser.
  - Documented the code.
  - Added first unit tests to use mocks.
  - Renamed constants to follow Golang's convention.
  - Added dependency: testify.mocks