### PR TITLE
Fix config path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@
 # Prevent configuration file from being uploaded
 syncron.yaml
 
+main
+

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To use Syncron, two important steps must be taken.
 - Create **configuration file**. 
     - Important information about config:
         - Yaml based
-        - Path: root of the project
+        - Path: ~/.config/
         - Naming: syncron.yaml
         - A minimal syncron configuration file is as follows:
 

--- a/pkg/bucketaws/setup.go
+++ b/pkg/bucketaws/setup.go
@@ -53,10 +53,10 @@ func ProcessDate(fromDate time.Time) []string {
 // Reading from file syncron.yaml
 func ConfigRead() {
 
-	viper.SetConfigFile("syncron.yaml")
-	//viper.SetConfigType("yaml")
-	viper.AddConfigPath("./config")
-	//viper.AddConfigPath(".")
+	viper.SetConfigName("syncron")
+	viper.SetConfigType("yaml")
+	viper.AddConfigPath(".config/")
+	viper.AddConfigPath(".")
 	viper.SetDefault("download_dir", "/tmp/syncron/")
 
 	// Reading from file


### PR DESCRIPTION
This PR fixes the configuration file read for Syncron.
The file will live under ~/.config/ folder.
Prior to this, Syncron could only read from the path where it was now running.
fixes https://github.com/RedHatCRE/syncron/issues/25
