### PR TITLE
Add golangcli-lint

### DIFF
--- a/.github/workflows/on-change.yaml
+++ b/.github/workflows/on-change.yaml
@@ -21,10 +21,12 @@ jobs:
         with:
           version: "2022.1"
           install-go: false
-      - name: "Build binary - Adhoc"
+      - name: "Build syncron binary"
         run: go build -v -o .go/builds/syncron main.go
       - name: "Run tests - All"
         run: go test -v ./...
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v3.3.1
       - name: "Publish artifacts - Binaries"
         uses: actions/upload-artifact@v3
         with:

--- a/cmd/syncron/download.go
+++ b/cmd/syncron/download.go
@@ -94,7 +94,10 @@ func onRun(cmd *cobra.Command, args []string) error {
 	filesToDownload := filter.Component(filterFlag)
 	for _, f := range filesToDownload {
 		logrus.Info("Downloading files for: ", f)
-		s3setup.DownloadFromBucket(svc, dwn, dates, f)
+		err := s3setup.DownloadFromBucket(svc, dwn, dates, f)
+		if err != nil {
+			logrus.Error("Error downloading:", f, err)
+		}
 	}
 	return nil
 }

--- a/pkg/log/config_test.go
+++ b/pkg/log/config_test.go
@@ -35,7 +35,10 @@ func (suite *ConfigureTestSuite) TestLevelOnDebug() {
 	parser := new(mocks.CLIParserMock)
 	parser.On("GetDebug").Return(true)
 
-	log.Configure(parser)
+	err := log.Configure(parser)
+	if err != nil {
+		logrus.Error("An error occured configuring logs", err)
+	}
 
 	assert.Equal(suite.T(), logrus.TraceLevel, logrus.GetLevel())
 }
@@ -46,8 +49,10 @@ func (suite *ConfigureTestSuite) TestLevelOnNoDebug() {
 	parser := new(mocks.CLIParserMock)
 	parser.On("GetDebug").Return(false)
 
-	log.Configure(parser)
-
+	err := log.Configure(parser)
+	if err != nil {
+		logrus.Error("An error occured configuring logs", err)
+	}
 	assert.Equal(suite.T(), logrus.InfoLevel, logrus.GetLevel())
 }
 

--- a/utils/files/files.go
+++ b/utils/files/files.go
@@ -30,7 +30,10 @@ import (
 func FilePathSetup(key *string, dwn *s3manager.Downloader) (*os.File, string) {
 
 	download_dir := viper.GetString("download_dir")
-	os.MkdirAll(download_dir+filepath.Dir(*key), 0700)
+	err := os.MkdirAll(download_dir+filepath.Dir(*key), 0700)
+	if err != nil {
+		logrus.Fatal("An error ocurred creating paths", err)
+	}
 	fileName := filepath.Base(*key)
 	fooFile, err := os.Create(download_dir + filepath.Dir(*key) + "/" + fileName)
 	if err != nil {


### PR DESCRIPTION
This change adds golangcli-lint to our test workflow.
For more: https://golangci-lint.run/