### PR TITLE
Check if sosreports file is already downloaded

### DIFF
--- a/pkg/bucketaws/setup.go
+++ b/pkg/bucketaws/setup.go
@@ -18,7 +18,6 @@ package s3setup
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -121,7 +120,7 @@ func DownloadFromBucket(svc *s3.S3, dwn *s3manager.Downloader, dates []string, b
 		for _, item := range resp.Contents {
 			for _, x := range dates {
 				if strings.Contains(*item.Key, x) {
-					absoluteFileName := getDownloadPath(*item.Key)
+					absoluteFileName := files.GetDownloadPath(*item.Key)
 
 					if files.FileExists(absoluteFileName) {
 						logrus.Info("File already exists: ", absoluteFileName)
@@ -170,11 +169,4 @@ func Credcheck(sess *session.Session) {
 			"Error reading credentials file. Check README for help.\n")
 	}
 	logrus.Info("Credentials file read succesfully")
-}
-
-// Get the absolute download path of the file
-func getDownloadPath(key string) string {
-	download_dir := viper.GetString("download_dir")
-	fileName := filepath.Base(key)
-	return filepath.Clean(download_dir + filepath.Dir(key) + "/" + fileName)
 }

--- a/utils/files/files.go
+++ b/utils/files/files.go
@@ -25,8 +25,8 @@ import (
 )
 
 // Creates a folder/file given the path in a recursive way
-// If the path finish with '/' it will create a file
-// Otherwise it will create a folder
+// If the path finish with '/' it will create a folder
+// Otherwise it will create a file
 func FilePathSetup(absoluteFilePath string) *os.File {
 	err := os.MkdirAll(filepath.Dir(absoluteFilePath), 0750)
 

--- a/utils/files/files.go
+++ b/utils/files/files.go
@@ -28,10 +28,10 @@ import (
 // If the path finish with '/' it will create a file
 // Otherwise it will create a folder
 func FilePathSetup(absoluteFilePath string) *os.File {
-	if err := os.MkdirAll(filepath.Dir(absoluteFilePath), 0750); err != nil {
-		if err != nil {
-			logrus.Fatal(err)
-		}
+	err := os.MkdirAll(filepath.Dir(absoluteFilePath), 0750)
+
+	if err != nil {
+		logrus.Fatal(err)
 	}
 
 	fileHandler, err := os.Create(filepath.Clean(absoluteFilePath))

--- a/utils/files/files.go
+++ b/utils/files/files.go
@@ -20,29 +20,34 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
-// This function takes a key from s3 and prepares the system for
-// download by recursively creating the path needed.
-func FilePathSetup(key *string, dwn *s3manager.Downloader) (*os.File, string) {
-
-	download_dir := viper.GetString("download_dir")
-	err := os.MkdirAll(download_dir+filepath.Dir(*key), 0700)
-	if err != nil {
-		logrus.Fatal("An error ocurred creating paths", err)
-	}
-	fileName := filepath.Base(*key)
-
-	fileHandler, err := os.Create(filepath.Clean(download_dir + filepath.Dir(*key) + "/" + fileName))
-
-	if err != nil {
-		fmt.Println(err)
+// Creates a folder/file given the path in a recursive way
+// If the path finish with '/' it will create a file
+// Otherwise it will create a folder
+func FilePathSetup(absoluteFilePath string) *os.File {
+	if err := os.MkdirAll(filepath.Dir(absoluteFilePath), 0750); err != nil {
+		if err != nil {
+			logrus.Fatal(err)
+		}
 	}
 
-	return fileHandler, fileName
+	fileHandler, err := os.Create(filepath.Clean(absoluteFilePath))
+
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	return fileHandler
+}
+
+func FileExists(filePath string) bool {
+	if _, err := os.Stat(filePath); err == nil {
+		return true
+	}
+	return false
 }
 
 // This function appends the prefix to components
@@ -52,12 +57,4 @@ func AppendPrefix(bPrefix string) string {
 	prefix := viper.GetString("prefix")
 	fullPrefix := fmt.Sprint(prefix + bPrefix)
 	return fullPrefix
-}
-
-func GetConfigPath() string {
-	dirname, err := os.UserHomeDir()
-	if err != nil {
-		logrus.Fatal(err)
-	}
-	return dirname + "/.config/"
 }

--- a/utils/files/files.go
+++ b/utils/files/files.go
@@ -58,3 +58,10 @@ func AppendPrefix(bPrefix string) string {
 	fullPrefix := fmt.Sprint(prefix + bPrefix)
 	return fullPrefix
 }
+
+// Get the absolute download path of the file
+func GetDownloadPath(key string) string {
+	download_dir := viper.GetString("download_dir")
+	fileName := filepath.Base(key)
+	return filepath.Clean(download_dir + filepath.Dir(key) + "/" + fileName)
+}


### PR DESCRIPTION
- Remove dependency of s3manager package in the files package
- Added FileExists method to check if a file is already downloaded
- Deleted the GetConfigPath function since os.UserConfigDir append the .config folder automatically in UNIX based distributions
- Checks if a file of the `sosreports` list has been already downloaded (it checks the absolute path that includes year, month, day and parquet name).
