### PR TITLE
Adding configuration struct to avoid calling viper everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,15 @@ To use Syncron, two important steps must be taken.
         - Naming: syncron.yaml
         - A minimal syncron configuration file is as follows:
 
-
             ```yaml
-            bucket: "<name of bucket to pull from>"
             s3:
               endpoint: "<endpoint>"
               region: "<region>"
+              bucket: "<name of bucket to pull from>"
             prefix: "<targeted keys starting path>"
-            download_dir: "<path where files will be downloaded>"
+            downloadDir: "<path where files will be downloaded>"
             ```
+
 - Proper credentials must be present on running machine at $HOME/.aws/credentials
 
 The credentials file has the following format:

--- a/cmd/syncron/download.go
+++ b/cmd/syncron/download.go
@@ -18,6 +18,7 @@ package cmd
 import (
 	"time"
 
+	"github.com/redhatcre/syncron/configuration"
 	s3setup "github.com/redhatcre/syncron/pkg/bucketaws"
 	"github.com/redhatcre/syncron/pkg/cli"
 	"github.com/redhatcre/syncron/utils/filter"
@@ -76,11 +77,13 @@ func onRun(cmd *cobra.Command, args []string) error {
 	fromDate := time.Now().AddDate(-Year, -Month, -Day)
 
 	// Reading configuration file
-	s3setup.ConfigRead()
+
+	c := configuration.Configuration{}
+	c.GetConfiguration()
 	// Creating AWS session
-	sess := s3setup.SetupSession()
+	sess := s3setup.SetupSession(c)
 	//Checking credentials
-	s3setup.Credcheck(sess)
+	s3setup.CredCheck(sess)
 	// Processing dates to download
 	dates := s3setup.ProcessDate(fromDate)
 	// Accessing bucket
@@ -95,10 +98,9 @@ func onRun(cmd *cobra.Command, args []string) error {
 		fromDate.Day(),
 	)
 	for _, f := range filesToDownload {
-		logrus.Info("Downloading files for: ", f)
-		err := s3setup.DownloadFromBucket(svc, dwn, dates, f)
+		err := s3setup.DownloadFromBucket(c, svc, dwn, dates, f)
 		if err != nil {
-			logrus.Error("Error downloading:", f, err)
+			logrus.Error("Error downloading: ", f, err)
 		}
 	}
 	return nil

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -1,0 +1,61 @@
+package configuration
+
+import (
+	"log"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+)
+
+type Configuration struct {
+	S3          S3Configuration `yaml:"s3"`
+	Prefix      string          `yaml:"prefix"`
+	DownloadDir string          `yaml:"download_dir"`
+	SosReports  []string        `yaml:"sosreports"`
+	Insights    []string        `yaml:"insights"`
+}
+
+type S3Configuration struct {
+	Bucket   string `yaml:"bucket"`
+	EndPoint string `yaml:"endpoint"`
+	Region   string `yaml:"region"`
+}
+
+// Setting up file formatting
+// Using Viper
+// Reading from file syncron.yaml
+func (c *Configuration) GetConfiguration() *Configuration {
+	userDirConfig, err := os.UserConfigDir()
+
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	viper.SetConfigName("syncron")
+	viper.SetConfigType("yaml")
+	viper.AddConfigPath(userDirConfig)
+	viper.AddConfigPath(".")
+
+	// Reading from file
+	err = viper.ReadInConfig()
+
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	err = viper.Unmarshal(&c)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if c.DownloadDir == "" {
+		c.DownloadDir = "/tmp/syncron/"
+	}
+
+	logrus.Info("Your configuration file was read succesfully")
+	logrus.Info("Reading from bucket: ", c.S3.Bucket)
+
+	return c
+}

--- a/pkg/bucketaws/setup.go
+++ b/pkg/bucketaws/setup.go
@@ -50,11 +50,11 @@ func ProcessDate(fromDate time.Time) []string {
 
 // Initialize a session with AWS SDK
 // It will read from the file located at ~/.aws/credentials and syncron/syncron.yaml
-func SetupSession(c configuration.Configuration) *session.Session {
+func SetupSession(config configuration.Configuration) *session.Session {
 
 	sess, err := session.NewSession(&aws.Config{
-		Region:   aws.String(c.S3.Region),
-		Endpoint: aws.String(c.S3.EndPoint),
+		Region:   aws.String(config.S3.Region),
+		Endpoint: aws.String(config.S3.EndPoint),
 	},
 	)
 	if err != nil {
@@ -76,14 +76,14 @@ func AccessBucket(sess *session.Session) (*s3.S3, *s3manager.Downloader) {
 
 // This function takes care of listing the keys in the bucket, filtering
 // through those that are needed.
-func DownloadFromBucket(c configuration.Configuration, svc *s3.S3, dwn *s3manager.Downloader, dates []string, bprefix string) error {
+func DownloadFromBucket(config configuration.Configuration, svc *s3.S3, dwn *s3manager.Downloader, dates []string, bprefix string) error {
 
 	var continuationToken *string
 
 	for {
 		resp, err := svc.ListObjectsV2(&s3.ListObjectsV2Input{
-			Bucket:            aws.String(c.S3.Bucket),
-			Prefix:            aws.String(files.AppendPrefix(c.Prefix, bprefix)),
+			Bucket:            aws.String(config.S3.Bucket),
+			Prefix:            aws.String(files.AppendPrefix(config.Prefix, bprefix)),
 			ContinuationToken: continuationToken,
 		})
 		if err != nil {
@@ -98,7 +98,7 @@ func DownloadFromBucket(c configuration.Configuration, svc *s3.S3, dwn *s3manage
 
 				logrus.Info("Downloading files for: ", bprefix)
 
-				absoluteFileName := files.GetDownloadPath(c.DownloadDir, *item.Key)
+				absoluteFileName := files.GetDownloadPath(config.DownloadDir, *item.Key)
 
 				if files.FileExists(absoluteFileName) {
 					logrus.Info("File already exists: ", absoluteFileName)
@@ -112,7 +112,7 @@ func DownloadFromBucket(c configuration.Configuration, svc *s3.S3, dwn *s3manage
 				_, err := dwn.Download(
 					fileHandler,
 					&s3.GetObjectInput{
-						Bucket: aws.String(c.S3.Bucket),
+						Bucket: aws.String(config.S3.Bucket),
 						Key:    aws.String(*item.Key),
 					})
 				duration := time.Since(start)

--- a/pkg/bucketaws/setup.go
+++ b/pkg/bucketaws/setup.go
@@ -17,10 +17,10 @@ package s3setup
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
+	"github.com/redhatcre/syncron/configuration"
 	files "github.com/redhatcre/syncron/utils/files"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -28,7 +28,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 // Builds dates from given date to current date,
@@ -49,40 +48,13 @@ func ProcessDate(fromDate time.Time) []string {
 	return dates
 }
 
-// Setting up file formatting
-// Using Viper
-// Reading from file syncron.yaml
-func ConfigRead() {
-	userDirConfig, err := os.UserConfigDir()
-
-	if err != nil {
-		logrus.Fatal(err)
-	}
-
-	viper.SetConfigName("syncron")
-	viper.SetConfigType("yaml")
-	viper.AddConfigPath(userDirConfig)
-	viper.AddConfigPath(".")
-	viper.SetDefault("download_dir", "/tmp/syncron/")
-
-	// Reading from file
-	err = viper.ReadInConfig()
-
-	if err != nil {
-		logrus.Fatal(err)
-	}
-
-	logrus.Info("Your configuration file was read succesfully")
-	logrus.Info("Reading from bucket: ", viper.Get("bucket"))
-}
-
 // Initialize a session with AWS SDK
 // It will read from the file located at ~/.aws/credentials and syncron/syncron.yaml
-func SetupSession() *session.Session {
+func SetupSession(c configuration.Configuration) *session.Session {
 
 	sess, err := session.NewSession(&aws.Config{
-		Region:   aws.String(viper.GetString("s3.region")),
-		Endpoint: aws.String(viper.GetString("s3.endpoint")),
+		Region:   aws.String(c.S3.Region),
+		Endpoint: aws.String(c.S3.EndPoint),
 	},
 	)
 	if err != nil {
@@ -104,14 +76,14 @@ func AccessBucket(sess *session.Session) (*s3.S3, *s3manager.Downloader) {
 
 // This function takes care of listing the keys in the bucket, filtering
 // through those that are needed.
-func DownloadFromBucket(svc *s3.S3, dwn *s3manager.Downloader, dates []string, bprefix string) error {
+func DownloadFromBucket(c configuration.Configuration, svc *s3.S3, dwn *s3manager.Downloader, dates []string, bprefix string) error {
 
 	var continuationToken *string
 
 	for {
 		resp, err := svc.ListObjectsV2(&s3.ListObjectsV2Input{
-			Bucket:            aws.String(viper.GetString("bucket")),
-			Prefix:            aws.String(files.AppendPrefix(bprefix)),
+			Bucket:            aws.String(c.S3.Bucket),
+			Prefix:            aws.String(files.AppendPrefix(c.Prefix, bprefix)),
 			ContinuationToken: continuationToken,
 		})
 		if err != nil {
@@ -119,38 +91,44 @@ func DownloadFromBucket(svc *s3.S3, dwn *s3manager.Downloader, dates []string, b
 		}
 		for _, item := range resp.Contents {
 			for _, x := range dates {
-				if strings.Contains(*item.Key, x) {
-					absoluteFileName := files.GetDownloadPath(*item.Key)
 
-					if files.FileExists(absoluteFileName) {
-						logrus.Info("File already exists: ", absoluteFileName)
-						continue
-					}
-
-					fileHandler := files.FilePathSetup(absoluteFileName)
-
-					logrus.Info("Downloading ", absoluteFileName)
-					start := time.Now()
-					_, err := dwn.Download(
-						fileHandler,
-						&s3.GetObjectInput{
-							Bucket: aws.String(viper.GetString("bucket")),
-							Key:    aws.String(*item.Key),
-						})
-					duration := time.Since(start)
-					logrus.Info("Download took: ", duration.Truncate(time.Second/2))
-
-					if err != nil {
-						fmt.Println("There was an error fetching key info.", err)
-						return err
-					}
-
-					defer func() {
-						if err := fileHandler.Close(); err != nil {
-							logrus.Print("Error closing file handler for: ", absoluteFileName)
-						}
-					}()
+				if !strings.Contains(*item.Key, x) {
+					continue
 				}
+
+				logrus.Info("Downloading files for: ", bprefix)
+
+				absoluteFileName := files.GetDownloadPath(c.DownloadDir, *item.Key)
+
+				if files.FileExists(absoluteFileName) {
+					logrus.Info("File already exists: ", absoluteFileName)
+					continue
+				}
+
+				fileHandler := files.FilePathSetup(absoluteFileName)
+
+				logrus.Info("Downloading ", absoluteFileName)
+				start := time.Now()
+				_, err := dwn.Download(
+					fileHandler,
+					&s3.GetObjectInput{
+						Bucket: aws.String(c.S3.Bucket),
+						Key:    aws.String(*item.Key),
+					})
+				duration := time.Since(start)
+				logrus.Info("Download took: ", duration.Truncate(time.Second/2))
+
+				if err != nil {
+					fmt.Println("There was an error fetching key info.", err)
+					return err
+				}
+
+				defer func() {
+					if err := fileHandler.Close(); err != nil {
+						logrus.Print("Error closing file handler for: ", absoluteFileName)
+					}
+				}()
+
 			}
 		}
 		if !aws.BoolValue(resp.IsTruncated) {
@@ -162,11 +140,13 @@ func DownloadFromBucket(svc *s3.S3, dwn *s3manager.Downloader, dates []string, b
 }
 
 // Check AWS credentials are correct
-func Credcheck(sess *session.Session) {
+func CredCheck(sess *session.Session) {
 	_, err := sess.Config.Credentials.Get()
+
 	if err != nil {
 		logrus.Fatal(
 			"Error reading credentials file. Check README for help.\n")
 	}
+
 	logrus.Info("Credentials file read succesfully")
 }

--- a/utils/files/files.go
+++ b/utils/files/files.go
@@ -21,7 +21,6 @@ import (
 	"path/filepath"
 
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 // Creates a folder/file given the path in a recursive way
@@ -52,16 +51,12 @@ func FileExists(filePath string) bool {
 
 // This function appends the prefix to components
 // Make sure prefix variable is initiated  properly in config file
-func AppendPrefix(bPrefix string) string {
-
-	prefix := viper.GetString("prefix")
-	fullPrefix := fmt.Sprint(prefix + bPrefix)
-	return fullPrefix
+func AppendPrefix(prefix string, bPrefix string) string {
+	return fmt.Sprint(prefix + bPrefix)
 }
 
-// Get the absolute download path of the file
-func GetDownloadPath(key string) string {
-	download_dir := viper.GetString("download_dir")
-	fileName := filepath.Base(key)
-	return filepath.Clean(download_dir + filepath.Dir(key) + "/" + fileName)
+// Get the absolute download path of the file based on
+// the folder and the file
+func GetDownloadPath(downloadDir string, destinationFile string) string {
+	return filepath.Join(filepath.Clean(downloadDir), filepath.Clean(destinationFile))
 }


### PR DESCRIPTION
- Modified the YAML structure of the configuration: The bucket terminology is part of the  service of aws so I think we can move it into the S3Configuration struct.
- Modified the YAML download_dir: Viper seems to not do the Unmarshall in the right way so it does not work if it has an underscore.
- Modified the docs about the configuration
- Added a new package configuration where will be the syncron and S3 configuration struct. Moved the setup configuration to this package.
- Modified the files package to avoid dependency from viper

At this way we don't have calls in all parts of the code to the viper module asking for the parameters we have provided.